### PR TITLE
Proposal: Object imports

### DIFF
--- a/fixtures/import-all/a.graphql
+++ b/fixtures/import-all/a.graphql
@@ -1,4 +1,4 @@
-# import B from "b.graphql"
+# import * from "b.graphql"
 
 type A {
   # test 1

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,6 +116,155 @@ type C2 {
   t.is(importSchema('fixtures/import-all/a.graphql'), expectedSDL)
 })
 
+test('importSchema: import all from string', t => {
+  const schemaC = `
+    type C1 {
+      id: ID!
+    }
+
+    type C2 {
+      id: ID!
+    }
+
+    type C3 {
+      id: ID!
+    }`
+
+  const schemaB = `
+    # import * from 'schemaC'
+
+    type B {
+      hello: String!
+      c1: C1
+      c2: C2
+    }`
+
+  const schemaA = `
+    # import B from "schemaB"
+
+    type A {
+      # test 1
+      first: String @first
+      second: Float
+      b: B
+    }`
+
+  const schemas = {
+    schemaB, schemaC
+  }
+
+  const expectedSDL = `\
+type A {
+  first: String @first
+  second: Float
+  b: B
+}
+
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+}
+
+type C1 {
+  id: ID!
+}
+
+type C2 {
+  id: ID!
+}
+`
+  t.is(importSchema(schemaA, schemas), expectedSDL)
+})
+
+test(`importSchema: import all mix 'n match`, t => {
+  const schemaB = `
+    # import C1, C2 from 'fixtures/import-all/c.graphql'
+
+    type B {
+      hello: String!
+      c1: C1
+      c2: C2
+    }`
+
+  const schemaA = `
+    # import * from "schemaB"
+
+    type A {
+      # test 1
+      first: String @first
+      second: Float
+      b: B
+    }`
+
+  const schemas = {
+    schemaB
+  }
+
+  const expectedSDL = `\
+type A {
+  first: String @first
+  second: Float
+  b: B
+}
+
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+}
+
+type C1 {
+  id: ID!
+}
+
+type C2 {
+  id: ID!
+}
+`
+  t.is(importSchema(schemaA, schemas), expectedSDL)
+})
+
+test(`importSchema: import all mix 'n match 2`, t => {
+
+  const schemaA = `
+    # import * from "fixtures/import-all/b.graphql"
+
+    type A {
+      # test 1
+      first: String @first
+      second: Float
+      b: B
+    }`
+
+  const expectedSDL = `\
+type A {
+  first: String @first
+  second: Float
+  b: B
+}
+
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+}
+
+type C1 {
+  id: ID!
+}
+
+type C2 {
+  id: ID!
+}
+
+type C3 {
+  id: ID!
+}
+`
+  t.is(importSchema(schemaA), expectedSDL)
+})
+
 test('importSchema: unions', t => {
   const expectedSDL = `\
 type A {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,7 +116,7 @@ type C2 {
   t.is(importSchema('fixtures/import-all/a.graphql'), expectedSDL)
 })
 
-test('importSchema: import all from string', t => {
+test('importSchema: import all from objects', t => {
   const schemaC = `
     type C1 {
       id: ID!
@@ -140,7 +140,7 @@ test('importSchema: import all from string', t => {
     }`
 
   const schemaA = `
-    # import B from "schemaB"
+    # import B from 'schemaB'
 
     type A {
       # test 1
@@ -150,7 +150,7 @@ test('importSchema: import all from string', t => {
     }`
 
   const schemas = {
-    schemaB, schemaC
+    schemaA, schemaB, schemaC
   }
 
   const expectedSDL = `\
@@ -175,6 +175,21 @@ type C2 {
 }
 `
   t.is(importSchema(schemaA, schemas), expectedSDL)
+})
+
+test(`importSchema: single object schema`, t => {
+  const schemaA = `
+    type A {
+      field: String
+    }`
+
+  const expectedSDL = `\
+type A {
+  field: String
+}
+`
+
+  t.is(importSchema(schemaA), expectedSDL)
 })
 
 test(`importSchema: import all mix 'n match`, t => {
@@ -255,10 +270,6 @@ type C1 {
 }
 
 type C2 {
-  id: ID!
-}
-
-type C3 {
   id: ID!
 }
 `

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,14 @@ export interface RawModule {
   from: string
 }
 
-/**
- * Read a schema file from disk
- *
- * @param f Filename
- * @returns File contents
- */
-const read: (f: string) => string =
-  (f: string): string => fs.readFileSync(f, { encoding: 'utf8' })
+const read = (schema: string, schemas?: { [key: string]: string }) => {
+  if (isFile(schema)) {
+    return fs.readFileSync(schema, { encoding: 'utf8' })
+  }
+  return schemas ? schemas[schema] : schema
+}
+
+const isFile = f => f.endsWith('.graphql')
 
 /**
  * Parse a single import line and extract imported types and schema filename
@@ -68,15 +68,16 @@ export function parseSDL(sdl: string): RawModule[] {
  * @param filePath File path to the initial schema file
  * @returns Single bundled schema with all imported types
  */
-export function importSchema(filePath: string): string {
-  const sdl = read(filePath)
+export function importSchema(schema: string, schemas: { [key: string]: string } = {}): string {
+  const sdl = read(schema)
   const document = parse(sdl, { noLocation: true })
 
   // Recursively process the imports, starting by importing all types from the initial schema
   let { allDefinitions, typeDefinitions } = collectDefinitions(
     ['*'],
     sdl,
-    path.resolve(filePath)
+    schema,
+    schemas
   )
 
   // Post processing of the final schema (missing types, unused types, etc.)
@@ -125,6 +126,7 @@ function collectDefinitions(
   imports: string[],
   sdl: string,
   filePath: string,
+  schemas?: { [key: string]: string },
   processedFiles: Set<string> = new Set(),
   typeDefinitions: TypeDefinitionNode[][] = [],
   allDefinitions: TypeDefinitionNode[][] = []
@@ -132,7 +134,7 @@ function collectDefinitions(
   allDefinitions: TypeDefinitionNode[][]
   typeDefinitions: TypeDefinitionNode[][]
 } {
-  const key = path.resolve(filePath)
+  const key = isFile(filePath) ? path.resolve(filePath) : filePath
   const dirname = path.dirname(filePath)
 
   // Get TypeDefinitionNodes from current schema
@@ -159,12 +161,13 @@ function collectDefinitions(
   // Process each file (recursively)
   rawModules.forEach(m => {
     // If it was not yet processed (in case of circular dependencies)
-    const moduleFilePath = path.resolve(path.join(dirname, m.from))
+    const moduleFilePath = isFile(filePath) ? path.resolve(path.join(dirname, m.from)) : m.from
     if (!processedFiles.has(moduleFilePath)) {
       collectDefinitions(
         m.imports,
         read(moduleFilePath),
         moduleFilePath,
+        schemas,
         processedFiles,
         typeDefinitions,
         allDefinitions

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,8 @@ export function parseSDL(sdl: string): RawModule[] {
  * @param filePath File path to the initial schema file
  * @returns Single bundled schema with all imported types
  */
-export function importSchema(schema: string, schemas: { [key: string]: string } = {}): string {
-  const sdl = read(schema)
+export function importSchema(schema: string, schemas?: { [key: string]: string }): string {
+  const sdl = read(schema, schemas) || schema
   const document = parse(sdl, { noLocation: true })
 
   // Recursively process the imports, starting by importing all types from the initial schema
@@ -165,7 +165,7 @@ function collectDefinitions(
     if (!processedFiles.has(moduleFilePath)) {
       collectDefinitions(
         m.imports,
-        read(moduleFilePath),
+        read(moduleFilePath, schemas),
         moduleFilePath,
         schemas,
         processedFiles,


### PR DESCRIPTION
I have added the possibility to use imports together with a collection of SDLs. This is useful when schemas do not come directly from file. I have added tests for these cases. It allows you to do:

```js
const schemaA = `
  # import B from 'schemaB'
  type A {
    field: B
  }`

const schemaB = `
  # import C1, C2 from 'schemaC'
  type B {
    field: C1
    dummy: C2
  }
`

const schemaC = `
   type C1 {
     field: String
   }
   type C2 {
     field: String
   }
`

importSchema(schemaA, { schemaB, schemaC })
```