### PR TITLE
fix: empty root schema #45

### DIFF
--- a/fixtures/imports-only/a.graphql
+++ b/fixtures/imports-only/a.graphql
@@ -1,0 +1,4 @@
+type Query {
+  first: String
+  second: Float
+}

--- a/fixtures/imports-only/all.graphql
+++ b/fixtures/imports-only/all.graphql
@@ -1,0 +1,2 @@
+# import Query.* from "a.graphql"
+#import Query.* from "b.graphql"

--- a/fixtures/imports-only/b.graphql
+++ b/fixtures/imports-only/b.graphql
@@ -1,0 +1,3 @@
+type Query {
+  third: String
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -54,6 +54,17 @@ test('parse: multi line import', t => {
   ])
 })
 
+test('importSchema: imports only', t => {
+  const expectedSDL = `\
+type Query {
+  first: String
+  second: Float
+  third: String
+}
+`
+  t.is(importSchema('fixtures/imports-only/all.graphql'), expectedSDL)
+})
+
 test('importSchema: field types', t => {
   const expectedSDL = `\
 type A {


### PR DESCRIPTION
* Added `getDocumentFromSDL` function to get a DocumentNode from SDL. If SDL is empty (containing only imports/comments/whitespaces) an empty DocumentNode will be created instead of parsing the schema which would lead to an error.
* Added unittest