### PR TITLE
Adding support and infra for Node 4, 6, and 8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/node
+references: 
+  run_tests: &run_tests
     steps:
       - checkout
       - run: sudo npm install -g yarn semantic-release@12.0.0
@@ -21,7 +19,26 @@ jobs:
       - store_artifacts:
           path: coverage
           prefix: coverage
-      - run: semantic-release
-      - run: yarn docs
+    # Removing this for now while I'm testing workflows.
+    #   - run: semantic-release
+    # Add this in after fan-out.
+    #   - run: yarn docs
       # needs proper NOW setup first
       # - run: yarn docs:publish
+
+jobs:
+  build-node4:
+    docker:
+      - image: circleci/node:4
+    <<: *run_tests
+  build-node6:
+    docker:
+      - image: circleci/node:6
+    <<: *run_tests
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build-node4
+      - build-node6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ references:
   run_tests: &run_tests
     steps:
       - checkout
-      - run: sudo npm install -g yarn semantic-release@12.0.0
+      - run: sudo npm install -g yarn
       - run: yarn install
       - run:
           name: test
@@ -19,12 +19,6 @@ references:
       - store_artifacts:
           path: coverage
           prefix: coverage
-    # Removing this for now while I'm testing workflows.
-    #   - run: semantic-release
-    # Add this in after fan-out.
-    #   - run: yarn docs
-      # needs proper NOW setup first
-      # - run: yarn docs:publish
 
 jobs:
   build-node4:
@@ -35,6 +29,19 @@ jobs:
     docker:
       - image: circleci/node:6
     <<: *run_tests
+  build-node8:
+    docker:
+      - image: circleci/node
+    <<: *run_tests
+  release:
+    docker: 
+      - image: circleci/node
+    steps: 
+      - run: sudo npm install -g semantic-release@12.0.0
+      - run: semantic-release
+      - run: yarn docs
+      # needs proper NOW setup first
+      # - run: yarn docs:publish
 
 workflows:
   version: 2
@@ -42,3 +49,9 @@ workflows:
     jobs:
       - build-node4
       - build-node6
+      - build-node8
+      - release:
+        requires: 
+          - build-node4
+          - build-node6
+          - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
       - build-node6
       - build-node8
       - release:
-        requires: 
-          - build-node4
-          - build-node6
-          - build-node8
+          requires: 
+            - build-node4
+            - build-node6
+            - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,8 @@ workflows:
       - build-node4
       - build-node6
       - build-node8
-      - release:
-        requires: 
-          - build-node4
-          - build-node6
-          - build-node8
+      # - release:
+      #   requires: 
+      #     - build-node4
+      #     - build-node6
+      #     - build-node8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
     docker: 
       - image: circleci/node
     steps: 
-      - run: sudo npm install -g semantic-release@12.0.0
+      - checkout
+      - run: sudo npm install -g yarn semantic-release@12.0.0
+      - run: yarn install
       - run: semantic-release
       - run: yarn docs
       # needs proper NOW setup first
@@ -50,8 +52,8 @@ workflows:
       - build-node4
       - build-node6
       - build-node8
-      # - release:
-      #   requires: 
-      #     - build-node4
-      #     - build-node6
-      #     - build-node8
+      - release:
+        requires: 
+          - build-node4
+          - build-node6
+          - build-node8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "graphql-import",
   "version": "0.0.0-semantic-release",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "license": "MIT",
   "repository": "git@github.com:graphcool/graphql-import.git",
   "files": [

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -1,4 +1,4 @@
-import { keyBy, uniqBy } from 'lodash'
+import { keyBy, uniqBy, includes } from 'lodash'
 import {
   DocumentNode,
   TypeDefinitionNode,
@@ -147,7 +147,7 @@ function collectNewTypeDefinitions(
     // collect missing argument input types
     if (
       !definitionPool.some(d => d.name.value === nodeTypeName) &&
-      !builtinTypes.includes(nodeTypeName)
+      !includes(builtinTypes, nodeTypeName)
     ) {
       const argTypeMatch = schemaMap[nodeTypeName]
       if (!argTypeMatch) {
@@ -165,7 +165,7 @@ function collectNewTypeDefinitions(
     const directiveName = directive.name.value
     if (
       !definitionPool.some(d => d.name.value === directiveName) &&
-      !builtinDirectives.includes(directiveName)
+      !includes(builtinDirectives, directiveName)
     ) {
       const directive = schemaMap[directiveName] as DirectiveDefinitionNode
       if (!directive) {


### PR DESCRIPTION
utilizing CircleCI's [workflows](https://circleci.com/docs/2.0/workflows/) feature, we can make sure that we can safely establish the `engines` field here. 

[i had explored compiling this code](https://github.com/jnwng/graphql-import/pull/3) using `babel`'s new TypeScript preset and using `babel-preset-env` to ensure we were transpiling _everything_ we needed, but i hit issues both with making sure sourcemaps were covering the original TypeScript source code as well as the fact that our use of instance methods like `Array.prototype.includes` couldn't safely be polyfilled without polluting the global scope. do the simple thing here and just use `lodash` and hope the test harness catches any further regressions.

i dont have access to the release flow, so whoever is reviewing this should ensure that my `semantic-release` changes are okay. thank you!