### PR TITLE
feat(Syntax): import with optional semicolon

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,13 @@ test('parseImportLine: parse single import', t => {
   })
 })
 
+test('parseImportLine: optional semicolon', t => {
+  t.deepEqual(parseImportLine(`import A from "schema.graphql";`), {
+    imports: ['A'],
+    from: 'schema.graphql',
+  })
+})
+
 test('parseImportLine: invalid', t => {
   t.throws(() => parseImportLine(`import from "schema.graphql"`), Error)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const isFile = f => f.endsWith('.graphql')
  */
 export function parseImportLine(importLine: string): RawModule {
   // Apply regex to import line
-  const matches = importLine.match(/^import (\*|(.*)) from ('|")(.*)('|")$/)
+  const matches = importLine.match(/^import (\*|(.*)) from ('|")(.*)('|");?$/)
   if (!matches || matches.length !== 6 || !matches[4]) {
     throw new Error(`Too few regex matches: ${matches}`)
   }


### PR DESCRIPTION
# What's changed
- Add support for optional semicolon
- Added test for change

```graphql
# import OtherType from './OtherType'
# import OtherType from './OtherType';
```

# Why?
I have a tendency of adding these semicolons and getting errors - old habits die hard. The error requires a bit of debugging and I figured a small change might save others a similar headache.

- [X] Tests and coverage passing locally