### PR TITLE
Fix multiple import declarations from the same path not working

### DIFF
--- a/fixtures/import-duplicate/a.graphql
+++ b/fixtures/import-duplicate/a.graphql
@@ -1,0 +1,6 @@
+type Query {
+  first: String
+  second: Float
+  third: String
+  unused: String
+}

--- a/fixtures/import-duplicate/all.graphql
+++ b/fixtures/import-duplicate/all.graphql
@@ -1,0 +1,2 @@
+# import Query.first, Query.second from "a.graphql"
+# import Query.third from "a.graphql"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -76,6 +76,17 @@ type Query {
   t.is(importSchema('fixtures/imports-only/all.graphql'), expectedSDL)
 })
 
+test('importSchema: import duplicate', t => {
+  const expectedSDL = `\
+type Query {
+  first: String
+  second: Float
+  third: String
+}
+`
+  t.is(importSchema('fixtures/import-duplicate/all.graphql'), expectedSDL)
+})
+
 test('importSchema: field types', t => {
   const expectedSDL = `\
 type A {

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,9 +193,20 @@ function collectDefinitions(
 
   // Read imports from current file
   const rawModules = parseSDL(sdl)
+  const mergedModules: RawModule[] = []
+
+  // Merge imports from the same path
+  rawModules.forEach(m => {
+    const mergedModule = mergedModules.find(mm => mm.from === m.from)
+    if (mergedModule) {
+      mergedModule.imports = mergedModule.imports.concat(m.imports)
+    } else {
+      mergedModules.push(m)
+    }
+  })
 
   // Process each file (recursively)
-  rawModules.forEach(m => {
+  mergedModules.forEach(m => {
     // If it was not yet processed (in case of circular dependencies)
     const moduleFilePath = isFile(filePath) ? path.resolve(path.join(dirname, m.from)) : m.from
     if (!processedFiles.has(moduleFilePath)) {


### PR DESCRIPTION
For more info see #115. The TL;DR is that currently it is not possible to do something like this:

```graphql
# import Query.first, Query.second from "a.graphql"
# import Query.third from "a.graphql"
```

I dove into the source code and found out this bug occurs because of the way circular dependencies are handled. I have no idea if this is the best way to fix this issue, so I'm open to better ways.